### PR TITLE
Change to official subgraph. Use tokenId for token id.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,12 +95,12 @@ function App(props) {
         </div>
         <p>Shift-C to show/hide controls</p>
         <div className='token-details'>
-          <p>{`${token.project.name} #${mintNumber(token.id)}`}</p>
+          <p>{`${token.project.name} #${mintNumber(token.tokenId)}`}</p>
           <p>{token.project.artistName}</p>
         </div>
       </div>
       <div className='content'>
-        {props.tokens != null ? <ABFrame tokenId={token.id} /> : "Loading..."}
+        {props.tokens != null ? <ABFrame tokenId={token.tokenId} /> : "Loading..."}
       </div>
     </div>
   );

--- a/src/fetchTokensByOwner.js
+++ b/src/fetchTokensByOwner.js
@@ -1,5 +1,5 @@
 async function fetchTokensByOwner(ownerAddress) {
-  const response = await fetch('https://api.thegraph.com/subgraphs/name/xenoliss/art-blocks-explorer', {
+  const response = await fetch('https://api.thegraph.com/subgraphs/name/artblocks/art-blocks', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -7,7 +7,7 @@ async function fetchTokensByOwner(ownerAddress) {
     body: JSON.stringify({
       query: `query FetchTokensByOwnerQuery {
         tokens(where: {owner: "${ownerAddress}"}) {
-          id
+          tokenId
           project {
             name
             artistName


### PR DESCRIPTION
It was mentioned in discord that the id field on the subgraph for Art Blocks would
change to be `<contract-id>-<token-id>`. In looking to change this it
was noticed that the project was not using the official subgraph for Art
Blocks.

This PR changes the app to use the official subgraph and updates the
attribute that we use for token id to `tokenId`.