### PR TITLE
Add fullscreen toggle key binding

### DIFF
--- a/hooks/useKeyboardControls.ts
+++ b/hooks/useKeyboardControls.ts
@@ -63,7 +63,9 @@ export function useKeyboardControls({
           break
         case 'f':
         case 'F':
-          e.preventDefault()
+          if (e.metaKey || e.ctrlKey) {
+            e.preventDefault()
+          }
           onToggleFullscreen?.()
           break
       }


### PR DESCRIPTION
Add Cmd/Ctrl+F key binding to toggle fullscreen.

This change provides a standard shortcut for toggling fullscreen and prevents the browser's find dialog from appearing when Cmd/Ctrl+F is pressed.

---
[Slack Thread](https://r4v3nllc.slack.com/archives/C08J16HMPPF/p1754703266473759?thread_ts=1754703266.473759&cid=C08J16HMPPF)

<a href="https://cursor.com/background-agent?bcId=bc-ed01b4be-9a7c-4992-90c0-b45df46b5211">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed01b4be-9a7c-4992-90c0-b45df46b5211">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

